### PR TITLE
Del 1 refaktor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ Tester kjøres gjennom Gradle, og kan kjøres i terminalen med følgende kommand
 ````bash
 ./gradlew test
 ````
+## Kjør kalkulator (demo)
+````bash
+./gradlew run
+````

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("java")
+    application
 }
 
 group = "no.nav"
@@ -14,6 +15,10 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     implementation("org.json:json:20240303")
     implementation("io.github.cdimascio:dotenv-java:3.0.2")
+}
+
+application {
+    mainClass.set("no.nav.Main")
 }
 
 tasks.test {

--- a/src/main/java/no/nav/dagpenger/DagpengerKalkulator.java
+++ b/src/main/java/no/nav/dagpenger/DagpengerKalkulator.java
@@ -30,9 +30,9 @@ public class DagpengerKalkulator {
         MAKS_ÅRLIG_DAGPENGERGRUNNLAG
     }
 
-    public final GrunnbeløpVerktøy grunnbeløpVerktøy;
+    private final GrunnbeløpVerktøy grunnbeløpVerktøy;
 
-    public final List<Årslønn> årslønner;
+    private final List<Årslønn> årslønner;
 
     public DagpengerKalkulator() {
         this.grunnbeløpVerktøy = new GrunnbeløpVerktøy();

--- a/src/main/java/no/nav/dagpenger/DagpengerKalkulator.java
+++ b/src/main/java/no/nav/dagpenger/DagpengerKalkulator.java
@@ -76,9 +76,9 @@ public class DagpengerKalkulator {
     public boolean harRettigheterTilDagpenger() {
         boolean harRettigheter = false;
 
-        if (summerNyligeÅrslønner(3) >= grunnbeløpVerktøy.hentTotaltGrunnbeløpForGittAntallÅr(3)) {
+        if (summerNyligeÅrslønner(3) / 3 > grunnbeløpVerktøy.hentTotaltGrunnbeløpForGittAntallÅr(3)) {
             harRettigheter = true;
-        } else if (hentÅrslønnVedIndeks(0).hentÅrslønn() >= grunnbeløpVerktøy.hentMinimumÅrslønnForRettPåDagpenger()) {
+        } else if (hentÅrslønnVedIndeks(0).hentÅrslønn() > grunnbeløpVerktøy.hentMinimumÅrslønnForRettPåDagpenger()) {
             harRettigheter = true;
         }
 

--- a/src/main/java/no/nav/dagpenger/DagpengerKalkulator.java
+++ b/src/main/java/no/nav/dagpenger/DagpengerKalkulator.java
@@ -34,9 +34,13 @@ public class DagpengerKalkulator {
 
     private final List<Årslønn> årslønner;
 
-    public DagpengerKalkulator() {
-        this.grunnbeløpVerktøy = new GrunnbeløpVerktøy();
+    public DagpengerKalkulator(GrunnbeløpVerktøy grunnbeløpVerktøy) {
+        this.grunnbeløpVerktøy = grunnbeløpVerktøy;
         this.årslønner = new ArrayList<>();
+    }
+
+    public DagpengerKalkulator() {
+        this(new GrunnbeløpVerktøy());
     }
 
     /**

--- a/src/main/java/no/nav/dagpenger/DagpengerKalkulator.java
+++ b/src/main/java/no/nav/dagpenger/DagpengerKalkulator.java
@@ -1,12 +1,12 @@
 package no.nav.dagpenger;
 
-import no.nav.grunnbeløp.GrunnbeløpVerktøy;
-import no.nav.årslønn.Årslønn;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
+import no.nav.grunnbeløp.GrunnbeløpVerktøy;
+import no.nav.årslønn.Årslønn;
 
 /**
  * Kalkulator for å beregne hvor mye dagpenger en person har rett på i Norge basert på dagens grunnbeløp (1G).
@@ -23,6 +23,12 @@ import java.util.List;
  * @version 1.0
  */
 public class DagpengerKalkulator {
+
+    public enum BeregningsMetode {
+        SISTE_ÅRSLØNN,
+        GJENNOMSNITTET_AV_TRE_ÅR,
+        MAKS_ÅRLIG_DAGPENGERGRUNNLAG
+    }
 
     public final GrunnbeløpVerktøy grunnbeløpVerktøy;
 
@@ -41,14 +47,17 @@ public class DagpengerKalkulator {
      */
     public double kalkulerDagsats() {
         double dagsats = 0;
-
         int arbeidsdagerIÅret = 260;
-        if (harRettigheterTilDagpenger() == true) {
-            if (velgBeregningsMetode() == "SISTE_ÅRSLØNN") {
+
+        if (harRettigheterTilDagpenger()) {
+            BeregningsMetode metode = velgBeregningsMetode();
+
+            if (metode == BeregningsMetode.SISTE_ÅRSLØNN) {
                 dagsats = Math.ceil(hentÅrslønnVedIndeks(0).hentÅrslønn() / arbeidsdagerIÅret);
-            } else if (velgBeregningsMetode() == "GJENNOMSNITTET_AV_TRE_ÅR") {
+            } else if (metode == BeregningsMetode.GJENNOMSNITTET_AV_TRE_ÅR) {
                 dagsats = Math.ceil((summerNyligeÅrslønner(3) / 3) / arbeidsdagerIÅret);
-            } else if (velgBeregningsMetode() == "MAKS_ÅRLIG_DAGPENGERGRUNNLAG") {
+            } else if (metode == BeregningsMetode.MAKS_ÅRLIG_DAGPENGERGRUNNLAG) {
+
                 dagsats = Math.ceil(grunnbeløpVerktøy.hentMaksÅrligDagpengegrunnlag() / arbeidsdagerIÅret);
             }
         }
@@ -76,19 +85,17 @@ public class DagpengerKalkulator {
      * Velger hva som skal være beregnings metode for dagsats ut ifra en person sine årslønner.
      * @return beregnings metode for dagsats.
      */
-    public String velgBeregningsMetode() {
-        String beregningsMetode;
+    public BeregningsMetode velgBeregningsMetode() {
+        double sisteÅrslønn = hentÅrslønnVedIndeks(0).hentÅrslønn();
+        double snittTreÅr = summerNyligeÅrslønner(3) / 3;
 
-        if (hentÅrslønnVedIndeks(0).hentÅrslønn() > (summerNyligeÅrslønner(3) / 3)) {
-           beregningsMetode = "SISTE_ÅRSLØNN";
-           if (hentÅrslønnVedIndeks(0).hentÅrslønn() > grunnbeløpVerktøy.hentMaksÅrligDagpengegrunnlag()) {
-               beregningsMetode = "MAKS_ÅRLIG_DAGPENGERGRUNNLAG";
-           }
-        } else {
-            beregningsMetode = "GJENNOMSNITTET_AV_TRE_ÅR";
+        if (sisteÅrslønn > snittTreÅr) {
+            if (sisteÅrslønn > grunnbeløpVerktøy.hentMaksÅrligDagpengegrunnlag()) {
+                return BeregningsMetode.MAKS_ÅRLIG_DAGPENGERGRUNNLAG;
+            }
+            return BeregningsMetode.SISTE_ÅRSLØNN;
         }
-
-        return beregningsMetode;
+        return BeregningsMetode.GJENNOMSNITTET_AV_TRE_ÅR;
     }
 
     public void leggTilÅrslønn(Årslønn årslønn) {

--- a/src/main/java/no/nav/grunnbeløp/GrunnbeløpAPI.java
+++ b/src/main/java/no/nav/grunnbeløp/GrunnbeløpAPI.java
@@ -1,13 +1,14 @@
 package no.nav.grunnbeløp;
 
-import io.github.cdimascio.dotenv.Dotenv;
-import org.json.JSONObject;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+
+import org.json.JSONObject;
+
+import io.github.cdimascio.dotenv.Dotenv;
 
 /**
  * Har ansvaret for å kontakte grunnbeløp API'et til NAV og henter dagens grunnbeløp.
@@ -15,7 +16,7 @@ import java.net.http.HttpResponse;
  * @author Emil Elton Nilsen
  * @version 1.0
  */
-public class GrunnbeløpAPI {
+public class GrunnbeløpAPI implements GrunnbeløpProvider {
 
     private final static Dotenv DOTENV = Dotenv.load();
 
@@ -23,6 +24,15 @@ public class GrunnbeløpAPI {
 
     public GrunnbeløpAPI() {
         this.grunnbeløpHTTPKlient = HttpClient.newHttpClient();
+    }
+
+    @Override
+    public double hentGrunnbeløp() {
+        try {
+            return hentGrunnbeløpFraAPI();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Problemer med tilkobling til grunnbeløp API'et", e);
+        }
     }
 
     /**
@@ -33,7 +43,7 @@ public class GrunnbeløpAPI {
      * @throws IOException
      * @throws InterruptedException
      */
-    public double hentGrunnbeløp() throws IOException, InterruptedException {
+    private double hentGrunnbeløpFraAPI() throws IOException, InterruptedException {
         HttpRequest grunnbeløpSpørring = HttpRequest.newBuilder(URI.create(DOTENV.get("G_API_URL"))).build();
 
         HttpResponse<String> grunnbeløpRespons =  this.grunnbeløpHTTPKlient.send(grunnbeløpSpørring, HttpResponse.BodyHandlers.ofString());

--- a/src/main/java/no/nav/grunnbeløp/GrunnbeløpProvider.java
+++ b/src/main/java/no/nav/grunnbeløp/GrunnbeløpProvider.java
@@ -1,0 +1,5 @@
+package no.nav.grunnbeløp;
+
+public interface GrunnbeløpProvider {
+    double hentGrunnbeløp();
+}

--- a/src/main/java/no/nav/grunnbeløp/GrunnbeløpVerktøy.java
+++ b/src/main/java/no/nav/grunnbeløp/GrunnbeløpVerktøy.java
@@ -1,7 +1,5 @@
 package no.nav.grunnbeløp;
 
-import java.io.IOException;
-
 /**
  * Verktøy med forskjellige hjelpemetoder til å kalkulere forskjellige grunnbeløpsverdier, som
  * bruker i prossesen for å kalkulere hvilken dagsats en person har rett på. Grunnbeløpet brukt
@@ -12,14 +10,15 @@ import java.io.IOException;
  */
 public class GrunnbeløpVerktøy {
 
-    private double grunnbeløp;
+    private final double grunnbeløp;
+
+
+    public GrunnbeløpVerktøy(GrunnbeløpProvider provider) {
+        this.grunnbeløp = provider.hentGrunnbeløp();
+    }
 
     public GrunnbeløpVerktøy() {
-        try {
-            this.grunnbeløp = new GrunnbeløpAPI().hentGrunnbeløp();
-        } catch (IOException | InterruptedException exception) {
-            System.out.println("Problemer med tilkobling til grunnbeløp API'et" + exception.getMessage());
-        }
+        this(new GrunnbeløpAPI());
     }
 
     /**

--- a/src/test/java/dagpenger/DagpengerKalkulatorTester.java
+++ b/src/test/java/dagpenger/DagpengerKalkulatorTester.java
@@ -1,10 +1,14 @@
 package dagpenger;
 
-import no.nav.dagpenger.DagpengerKalkulator;
-import no.nav.årslønn.Årslønn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import no.nav.dagpenger.DagpengerKalkulator;
+import no.nav.dagpenger.DagpengerKalkulator.BeregningsMetode;
+import no.nav.årslønn.Årslønn;
 
 public class DagpengerKalkulatorTester {
 
@@ -50,7 +54,8 @@ public class DagpengerKalkulatorTester {
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 550000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 110000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 24000));
-        assertEquals("SISTE_ÅRSLØNN", dagpengerKalkulator.velgBeregningsMetode());
+        // assertEquals("SISTE_ÅRSLØNN", dagpengerKalkulator.velgBeregningsMetode());
+        assertEquals(BeregningsMetode.SISTE_ÅRSLØNN, dagpengerKalkulator.velgBeregningsMetode());
     }
 
     @Test
@@ -59,7 +64,8 @@ public class DagpengerKalkulatorTester {
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 830000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 110000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 24000));
-        assertEquals("MAKS_ÅRLIG_DAGPENGERGRUNNLAG", dagpengerKalkulator.velgBeregningsMetode());
+        // assertEquals("MAKS_ÅRLIG_DAGPENGERGRUNNLAG", dagpengerKalkulator.velgBeregningsMetode());
+        assertEquals(BeregningsMetode.MAKS_ÅRLIG_DAGPENGERGRUNNLAG, dagpengerKalkulator.velgBeregningsMetode());
     }
 
     @Test
@@ -68,7 +74,8 @@ public class DagpengerKalkulatorTester {
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 330000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 400000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 334000));
-        assertEquals("GJENNOMSNITTET_AV_TRE_ÅR", dagpengerKalkulator.velgBeregningsMetode());
+        // assertEquals("GJENNOMSNITTET_AV_TRE_ÅR", dagpengerKalkulator.velgBeregningsMetode());
+        assertEquals(BeregningsMetode.GJENNOMSNITTET_AV_TRE_ÅR, dagpengerKalkulator.velgBeregningsMetode());
     }
 
     @Test

--- a/src/test/java/dagpenger/DagpengerKalkulatorTester.java
+++ b/src/test/java/dagpenger/DagpengerKalkulatorTester.java
@@ -12,9 +12,13 @@ import no.nav.årslønn.Årslønn;
 
 public class DagpengerKalkulatorTester {
 
+    private static DagpengerKalkulator kalkulatorMedFastG(double g) {
+        return new DagpengerKalkulator(new no.nav.grunnbeløp.GrunnbeløpVerktøy(() -> g));
+    }
+
     @Test
     public void testSkalHaRettigheterTilDagpengerUtifraSisteTreÅrslønner()  {
-        DagpengerKalkulator dagpengerKalkulator = new DagpengerKalkulator();
+        DagpengerKalkulator dagpengerKalkulator = kalkulatorMedFastG(100_000);
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 445000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 465000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 300000));
@@ -23,7 +27,7 @@ public class DagpengerKalkulatorTester {
 
     @Test
     public void testSkalHaRetigheterTilDagpengerSisteÅrslønn() {
-        DagpengerKalkulator dagpengerKalkulator = new DagpengerKalkulator();
+        DagpengerKalkulator dagpengerKalkulator = kalkulatorMedFastG(100_000);
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 0));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 0));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 467000));
@@ -32,7 +36,7 @@ public class DagpengerKalkulatorTester {
 
     @Test
     public void testSkalIkkeHaRettigheterTilDagpengerSisteTreÅrslønner()  {
-        DagpengerKalkulator dagpengerKalkulator = new DagpengerKalkulator();
+        DagpengerKalkulator dagpengerKalkulator = kalkulatorMedFastG(100_000);
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 44000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 52000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 100000));
@@ -41,7 +45,7 @@ public class DagpengerKalkulatorTester {
 
     @Test
     public void testSkalIkkeHaRettigheterTilDagpengerSisteÅrslønn()  {
-        DagpengerKalkulator dagpengerKalkulator = new DagpengerKalkulator();
+        DagpengerKalkulator dagpengerKalkulator = kalkulatorMedFastG(100_000);
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 0));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 130000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 0));
@@ -50,7 +54,7 @@ public class DagpengerKalkulatorTester {
 
     @Test
     public void testBeregningsMetodeBlirSattTilSisteÅrslønn() {
-        DagpengerKalkulator dagpengerKalkulator = new DagpengerKalkulator();
+        DagpengerKalkulator dagpengerKalkulator = kalkulatorMedFastG(100_000);
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 550000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 110000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 24000));
@@ -60,7 +64,7 @@ public class DagpengerKalkulatorTester {
 
     @Test
     public void testBeregningsMetodeBlirSattTilMaksÅrslønnGrunnbeløp() {
-        DagpengerKalkulator dagpengerKalkulator = new DagpengerKalkulator();
+        DagpengerKalkulator dagpengerKalkulator = kalkulatorMedFastG(100_000);
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 830000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 110000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 24000));
@@ -70,7 +74,7 @@ public class DagpengerKalkulatorTester {
 
     @Test
     public void testBeregningsMetodeBlirSattTilGjennomsnittetAvTreÅr() {
-        DagpengerKalkulator dagpengerKalkulator = new DagpengerKalkulator();
+        DagpengerKalkulator dagpengerKalkulator = kalkulatorMedFastG(100_000);
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 330000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 400000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 334000));
@@ -80,7 +84,7 @@ public class DagpengerKalkulatorTester {
 
     @Test
     public void testDagsatsKalkulertUtifraSisteÅrslønn() {
-        DagpengerKalkulator dagpengerKalkulator = new DagpengerKalkulator();
+        DagpengerKalkulator dagpengerKalkulator = kalkulatorMedFastG(100_000);
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 550000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 110000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 24000));
@@ -89,16 +93,16 @@ public class DagpengerKalkulatorTester {
 
     @Test
     public void testDagsatsKalkulertUtifraMaksÅrligGrunnbeløp() {
-        DagpengerKalkulator dagpengerKalkulator = new DagpengerKalkulator();
+        DagpengerKalkulator dagpengerKalkulator = kalkulatorMedFastG(100_000);
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 830000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 24000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 110000));
-        assertEquals(3004, dagpengerKalkulator.kalkulerDagsats());
+        assertEquals(2308, dagpengerKalkulator.kalkulerDagsats());
     }
 
     @Test
     public void testDagsatsKalkulertUtifraTreÅrsGjennomsnitt() {
-        DagpengerKalkulator dagpengerKalkulator = new DagpengerKalkulator();
+        DagpengerKalkulator dagpengerKalkulator = kalkulatorMedFastG(100_000);
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 330000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 334000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 400000));
@@ -107,7 +111,7 @@ public class DagpengerKalkulatorTester {
 
     @Test
     public void testDagsatsKalkulertIkkeRettPåDagpenger() {
-        DagpengerKalkulator dagpengerKalkulator = new DagpengerKalkulator();
+        DagpengerKalkulator dagpengerKalkulator = kalkulatorMedFastG(100_000);
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2025, 80000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2024, 100000));
         dagpengerKalkulator.leggTilÅrslønn(new Årslønn(2023, 70000));


### PR DESCRIPTION
PRen rydder opp i kalkulatoren for enklere videreutvikling, bedre testbarhet og robusthet.

- La til ./gradlew run og oppdaterte README deretter.
- Byttet beregningsmetode fra String til enum for å unngå feilbruk av == og gjøre logikken mer tydelig.
- Felter i DagpengerKalkulator gjort private.
- Introduserte GrunnbeløpProvider + dependency injection, som skiller API-kall fra domenelogikk og gjør testene uavhengige av nett.
- Gjorde testene deterministiske ved å bruke fast grunnbeløp.
- Oppdaterte også kvalifiseringsregelen til å følge README (snitt siste 3 år > 3G, og siste år > 1,5G).